### PR TITLE
feat: apply capyuniverse shell styling to tools

### DIFF
--- a/CapyAdv.html
+++ b/CapyAdv.html
@@ -23,6 +23,8 @@
     .card{transition:transform .2s ease, box-shadow .2s ease}
     .card:hover{transform:translateY(-2px);box-shadow:0 10px 30px rgba(0,0,0,.35)}
   </style>
+  <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="min-h-screen flex flex-col text-[15px]">
   <!-- Header -->

--- a/CapyChat.html
+++ b/CapyChat.html
@@ -136,6 +136,8 @@
 
   gtag('config', 'G-3FFD7ZEBN1');
 </script>
+  <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -261,7 +263,7 @@
     <script>
         let apiKeys = { gemini: '', openai: '', claude: '', perplexity: '' };
         let apiKey = ''; 
-        const GEMINI_API_URL_BASE = "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=";
+        const GEMINI_API_URL_BASE = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=";
         const currentPageId = 'CapyChat'; 
         const API_KEY_STORAGE_PREFIX = 'capyUniverseApiKey_';
         let chatConversationHistory = []; // Para armazenar o histórico do chat atual

--- a/CapyConciliaFacil.html
+++ b/CapyConciliaFacil.html
@@ -5,6 +5,8 @@
   <meta http-equiv="refresh" content="0; url=capyconciliador.html">
   <title>Redirecionando para CapyConciliaFacil…</title>
   <script>window.location.replace('capyconciliador.html');</script>
+  <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body>
   <p style="color:#fff;background:#0b0b14;font-family:Inter,system-ui,sans-serif;padding:2rem;">

--- a/CapyCronosLegal.html
+++ b/CapyCronosLegal.html
@@ -5,6 +5,8 @@
   <meta http-equiv="refresh" content="0; url=capycronos.html">
   <title>Redirecionando para CapyCronosLegal…</title>
   <script>window.location.replace('capycronos.html');</script>
+  <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body>
   <p style="color:#fff;background:#0b0b14;font-family:Inter,system-ui,sans-serif;padding:2rem;">

--- a/CapyDados.html
+++ b/CapyDados.html
@@ -166,6 +166,8 @@
 
   gtag('config', 'G-3FFD7ZEBN1');
 </script>
+  <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -321,7 +323,7 @@
 
         let apiKeys = { gemini: '', openai: '', claude: '', perplexity: '' };
         let apiKey = ''; 
-        const GEMINI_API_URL_BASE = "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=";
+        const GEMINI_API_URL_BASE = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=";
         const currentPageId = 'CapyDoc'; 
         let extractedTexts = { 
             doc: '' 

--- a/CapyDecisao.html
+++ b/CapyDecisao.html
@@ -59,6 +59,7 @@
   gtag('config', 'G-3FFD7ZEBN1');
 </script>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="dark min-h-screen flex flex-col text-[15px]">
 
@@ -251,7 +252,7 @@
             `;
             
             try {
-                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
+                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })

--- a/CapyFiscal.html
+++ b/CapyFiscal.html
@@ -151,6 +151,8 @@
 </script>
 
 
+  <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -291,7 +293,7 @@
 
         let apiKeys = { gemini: '', openai: '', claude: '', perplexity: '' };
         let apiKey = ''; // Chave Gemini ativa
-        const GEMINI_API_URL_BASE = "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=";
+        const GEMINI_API_URL_BASE = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=";
         const currentPageId = 'CapyFiscal'; 
         let rawMarkdownResponse = ''; 
         let extractedFileContent = ''; // Para armazenar o conteúdo do ficheiro fiscal

--- a/CapyGem.html
+++ b/CapyGem.html
@@ -240,6 +240,8 @@
 </script>
 
 
+  <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 

--- a/CapyGrana.html
+++ b/CapyGrana.html
@@ -81,6 +81,8 @@
   gtag('js', new Date());
   gtag('config', 'G-3FFD7ZEBN1', { 'page_path': location.pathname });
 </script>
+  <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-50 text-gray-900 transition-colors duration-300">
     <div class="flex h-screen">

--- a/capyapmaker.html
+++ b/capyapmaker.html
@@ -393,6 +393,7 @@
     gtag('config', 'G-3FFD7ZEBN1', { 'page_path': location.pathname });
 </script>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -716,7 +717,7 @@
             chatHistory.push({ role: "user", parts: [{ text: prompt }] });
 
             const payload = { contents: chatHistory };
-            const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${geminiApiKey}`;
+            const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${geminiApiKey}`;
 
             const response = await fetch(apiUrl, {
                 method: 'POST',
@@ -816,7 +817,7 @@
             chatHistory.push({ role: "user", parts: [{ text: prompt }] });
 
             const payload = { contents: chatHistory };
-            const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${geminiApiKey}`;
+            const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${geminiApiKey}`;
 
             const response = await fetch(apiUrl, {
                 method: 'POST',

--- a/capyaudiencias.html
+++ b/capyaudiencias.html
@@ -97,6 +97,7 @@
       gtag('config', 'G-3FFD7ZEBN1', { 'page_path': location.pathname });
     </script>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 
 <body class="dark min-h-screen flex flex-col text-[15px]">

--- a/capybranding.html
+++ b/capybranding.html
@@ -203,6 +203,7 @@
     </style>
 
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 
 <body class="flex flex-col min-h-screen">

--- a/capybula.html
+++ b/capybula.html
@@ -146,6 +146,7 @@
   gtag('config', 'G-3FFD7ZEBN1');
 </script>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 
 <body class="dark min-h-screen flex flex-col text-[15px]">

--- a/capybyte.html
+++ b/capybyte.html
@@ -80,6 +80,7 @@
 </script>
 
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -240,7 +241,7 @@ async function diagnoseProblem() {
     `;
 
     try {
-        const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
+        const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })

--- a/capycaption.html
+++ b/capycaption.html
@@ -22,6 +22,8 @@
     .chip{background:rgba(255,255,255,.06);border:1px solid var(--glass-border);padding:.35rem .6rem;border-radius:.6rem}
     .card{border:1px solid var(--glass-border)}
   </style>
+  <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="min-h-screen flex flex-col text-[15px]">
 <header class="bg-zinc-900/80 backdrop-blur-md shadow-lg flex justify-between items-center fixed top-0 left-0 right-0 z-40 h-16 px-4 sm:px-6">

--- a/capychart.html
+++ b/capychart.html
@@ -87,6 +87,7 @@
 </script>
 
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 

--- a/capychat.html
+++ b/capychat.html
@@ -157,6 +157,7 @@
 </script>
 
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -304,7 +305,7 @@
             toggleLoading(true);
             
             try {
-                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
+                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ 

--- a/capycid.html
+++ b/capycid.html
@@ -305,6 +305,7 @@
   gtag('config', 'G-3FFD7ZEBN1');
 </script>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 

--- a/capyclt.html
+++ b/capyclt.html
@@ -409,7 +409,9 @@
   gtag('js', new Date());
 
   gtag('config', 'G-3FFD7ZEBN1');
-</script></head>
+</script>  <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
+</head>
 
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 

--- a/capyconciliador.html
+++ b/capyconciliador.html
@@ -103,6 +103,7 @@
   gtag('config', 'G-3FFD7ZEBN1');
 </script>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 
 <body class="dark min-h-screen flex flex-col text-[15px]">

--- a/capycontrato.html
+++ b/capycontrato.html
@@ -89,6 +89,7 @@
   gtag('config', 'G-3FFD7ZEBN1', { 'page_path': location.pathname });
 </script>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 

--- a/capyconverter.html
+++ b/capyconverter.html
@@ -134,6 +134,8 @@
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-3FFD7ZEBN1');
     </script>
+  <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 
 <body class="dark min-h-screen flex flex-col text-[15px]">

--- a/capycopy.html
+++ b/capycopy.html
@@ -154,6 +154,7 @@
   gtag('config', 'G-3FFD7ZEBN1');
 </script>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 
 <body class="dark min-h-screen flex flex-col text-[15px]">

--- a/capycronos.html
+++ b/capycronos.html
@@ -110,6 +110,7 @@
   gtag('config', 'G-3FFD7ZEBN1');
 </script>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">

--- a/capycsv.html
+++ b/capycsv.html
@@ -25,6 +25,8 @@
     .hidden-input{position:absolute;inset:0;opacity:0}
     .scrollbar-thin::-webkit-scrollbar{width:6px;height:6px}.scrollbar-thin::-webkit-scrollbar-thumb{background:#3f3f46;border-radius:60px}
   </style>
+  <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="min-h-screen flex flex-col text-[15px]">
   <header class="bg-zinc-900/80 backdrop-blur-md shadow-lg flex justify-between items-center fixed top-0 left-0 right-0 z-40 h-16 px-4 sm:px-6">

--- a/capycurriculo.html
+++ b/capycurriculo.html
@@ -100,6 +100,7 @@
 </script>
 
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -396,7 +397,7 @@ async function handleAnalyze() {
     `;
     
     try {
-        const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
+        const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })

--- a/capydados.html
+++ b/capydados.html
@@ -178,6 +178,7 @@
   gtag('config', 'G-3FFD7ZEBN1');
 </script>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 

--- a/capydebate.html
+++ b/capydebate.html
@@ -113,6 +113,7 @@
 </script>
 
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -329,7 +330,7 @@
             toggleButtonLoading(dom.sendArgumentButton, true);
             
             try {
-                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
+                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ contents: debateChatHistory }) 

--- a/capydetector.html
+++ b/capydetector.html
@@ -105,6 +105,7 @@
 </script>
 
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -297,7 +298,7 @@ async function handleAnalyzeText() {
     `;
     
     try {
-        const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
+        const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })

--- a/capydiario.html
+++ b/capydiario.html
@@ -100,6 +100,7 @@
   gtag('config', 'G-3FFD7ZEBN1');
 </script>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -286,7 +287,7 @@
             prompt += "\nResponda de forma clara e construtiva, usando Markdown simples se apropriado.";
             
             try {
-                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
+                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })

--- a/capydidatica.html
+++ b/capydidatica.html
@@ -107,6 +107,7 @@
   gtag('config', 'G-3FFD7ZEBN1');
 </script>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -313,7 +314,7 @@
             `;
             
             try {
-                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
+                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })

--- a/capydoc.html
+++ b/capydoc.html
@@ -101,6 +101,7 @@
   gtag('config', 'G-3FFD7ZEBN1');
 </script>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -304,7 +305,7 @@ async function handleAnalyzeDocument() {
     prompt += "\nResponda de forma clara e bem estruturada, usando Markdown simples para formatação, se apropriado.";
     
     try {
-        // Corrigido: Alterado o modelo para 'gemini-1.0-pro' (ou outro modelo válido)
+        // Corrigido: Alterado o modelo para 'gemini-2.0-flash' (modelo atualizado)
         const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },

--- a/capydockit.html
+++ b/capydockit.html
@@ -38,6 +38,8 @@
     .category-content{max-height:0;overflow:hidden;transition:max-height 0.3s ease}
     .category-content.expanded{max-height:500px}
   </style>
+  <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="min-h-screen flex flex-col text-[15px]">
   <!-- Header -->

--- a/capyemail.html
+++ b/capyemail.html
@@ -94,6 +94,7 @@
       gtag('config', 'G-3FFD7ZEBN1', { 'page_path': location.pathname });
     </script>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -261,7 +262,7 @@
             `;
             
             try {
-                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
+                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })

--- a/capyescritor.html
+++ b/capyescritor.html
@@ -94,6 +94,7 @@
         }
     </style>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -300,7 +301,7 @@
             `;
             
             try {
-                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
+                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })

--- a/capyexcel.html
+++ b/capyexcel.html
@@ -120,6 +120,7 @@
         }
     </style>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -311,7 +312,7 @@
             `;
             
             try {
-                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
+                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })

--- a/capyexplica.html
+++ b/capyexplica.html
@@ -155,6 +155,7 @@
         .markdown-output p:last-child { margin-bottom: 0; }
     </style>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 

--- a/capyfiscal.html
+++ b/capyfiscal.html
@@ -105,6 +105,7 @@
         }
     </style>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -291,7 +292,7 @@
             `;
             
             try {
-                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
+                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })

--- a/capyfix.html
+++ b/capyfix.html
@@ -85,6 +85,7 @@
     .scrollbar-thin::-webkit-scrollbar-track{ background:rgba(255,255,255,.06); }
   </style>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 
 <body class="min-h-screen flex flex-col text-[15px]">

--- a/capyflashcards.html
+++ b/capyflashcards.html
@@ -203,6 +203,7 @@
   gtag('config', 'G-3FFD7ZEBN1');
 </script>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 

--- a/capygem.html
+++ b/capygem.html
@@ -115,6 +115,7 @@
         .markdown-output p:last-child { margin-bottom: 0; }
     </style>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -329,7 +330,7 @@
             toggleButtonLoading(dom.sendChatButton, true);
             
             try {
-                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
+                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ contents: chatHistory }) 

--- a/capygrana.html
+++ b/capygrana.html
@@ -107,6 +107,7 @@
   gtag('config', 'G-3FFD7ZEBN1');
 </script>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -316,7 +317,7 @@
             `;
             
             try {
-                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
+                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })

--- a/capyhistoriador.html
+++ b/capyhistoriador.html
@@ -106,6 +106,7 @@
   gtag('config', 'G-3FFD7ZEBN1');
 </script>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 

--- a/capyide.html
+++ b/capyide.html
@@ -13,6 +13,7 @@
   <link rel="stylesheet" href="tool-styles.css">
 
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="min-h-screen flex flex-col text-[15px]">
     <header class="global-header w-full fixed top-0 left-0 right-0 z-40 py-1">

--- a/capyimg.html
+++ b/capyimg.html
@@ -82,9 +82,10 @@
     .scrollbar-thin::-webkit-scrollbar-track{ background:rgba(255,255,255,.06); }
   </style>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 
-<body class="min-h-screen flex flex-col">
+<body class="min-h-screen flex flex-col" data-cu-skip-shell="true">
   <div class="cu-stars"></div><div class="cu-stage"></div>
 
   <!-- HEADER -->

--- a/capyimgtxt.html
+++ b/capyimgtxt.html
@@ -74,6 +74,7 @@
         }
     </style>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 
 <body class="dark min-h-screen flex flex-col text-[15px]">

--- a/capylanding.html
+++ b/capylanding.html
@@ -104,6 +104,8 @@
             border: 1px solid var(--glass-border)
         }
     </style>
+  <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 
 <body class="min-h-screen flex flex-col text-[15px]">

--- a/capymarkdown.html
+++ b/capymarkdown.html
@@ -84,6 +84,7 @@
         }
     </style>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 

--- a/capymeditacao.html
+++ b/capymeditacao.html
@@ -96,6 +96,7 @@
       gtag('config', 'G-3FFD7ZEBN1', { 'page_path': location.pathname });
     </script>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -288,7 +289,7 @@
             `;
             
             try {
-                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
+                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })

--- a/capymetas.html
+++ b/capymetas.html
@@ -97,6 +97,7 @@
       gtag('config', 'G-3FFD7ZEBN1', { 'page_path': location.pathname });
     </script>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -299,7 +300,7 @@
             `;
             
             try {
-                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
+                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })

--- a/capyminuta.html
+++ b/capyminuta.html
@@ -87,6 +87,7 @@
         .markdown-output h3 { font-size: 1.125rem; }   /* text-lg */
     </style>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -327,7 +328,7 @@
             `;
             
             try {
-                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
+                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })

--- a/capyocr.html
+++ b/capyocr.html
@@ -76,6 +76,7 @@
         }
     </style>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="dark min-h-screen flex flex-col text-[15px]">
 

--- a/capypdf.html
+++ b/capypdf.html
@@ -190,6 +190,7 @@
         }
     </style>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -433,7 +434,7 @@
         // IA Gemini API
         async function callGemini(prompt, chatHistoryArr = []) {
             if (!apiKey) throw new Error("API Key não configurada.");
-            const url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=" + apiKey;
+            const url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=" + apiKey;
             let contents = chatHistoryArr.length
                 ? chatHistoryArr.map(turn => ({ role: turn.role, parts: [{ text: turn.text }] }))
                 : [{ parts: [{ text: prompt }], role: "user" }];

--- a/capypdflab.html
+++ b/capypdflab.html
@@ -27,6 +27,8 @@
     .hidden-input{position:absolute;inset:0;opacity:0}
     .scrollbar-thin::-webkit-scrollbar{width:6px;height:6px}.scrollbar-thin::-webkit-scrollbar-thumb{background:#3f3f46;border-radius:60px}
   </style>
+  <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="min-h-screen flex flex-col text-[15px]">
   <header class="bg-zinc-900/80 backdrop-blur-md shadow-lg flex justify-between items-center fixed top-0 left-0 right-0 z-40 h-16 px-4 sm:px-6">

--- a/capyplanner.html
+++ b/capyplanner.html
@@ -101,6 +101,7 @@
         .markdown-output h3 { font-size: 1.25rem; } .markdown-output h4 { font-size: 1.125rem; }
     </style>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -282,7 +283,7 @@
             `;
             
             try {
-                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
+                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })

--- a/capyprompt.html
+++ b/capyprompt.html
@@ -138,6 +138,7 @@
         }
     </style>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 

--- a/capypsico.html
+++ b/capypsico.html
@@ -93,6 +93,7 @@
          .markdown-output p:last-child { margin-bottom: 0; }
     </style>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -254,7 +255,7 @@
             `;
             
             try {
-                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
+                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ 

--- a/capyquiz.html
+++ b/capyquiz.html
@@ -53,6 +53,7 @@
       function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-3FFD7ZEBN1');
     </script>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 
 <body class="dark min-h-screen flex flex-col text-[15px]">

--- a/capyreceita.html
+++ b/capyreceita.html
@@ -102,6 +102,7 @@
         }
     </style>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="dark min-h-screen flex flex-col text-[15px]">
 
@@ -292,7 +293,7 @@
             const prompt = `Aja como CapyReceita, um chef de cozinha criativo. Crie uma receita com base nos seguintes critérios:\n- Ingredientes: "${ingredients}"\n- Preferências/Restrições: "${preferences || "Nenhuma"}"\n- Tipo de Refeição: ${mealType}\nA receita deve ter um Nome Criativo, uma lista de Ingredientes, Instruções passo-a-passo, e uma Dica do Chef. Formate usando Markdown simples. Responda APENAS com a receita.`;
             
             try {
-                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
+                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })
@@ -339,7 +340,7 @@
             outputElement.innerHTML = `<p class="text-zinc-400">A analisar...</p>`;
 
             try {
-                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
+                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })

--- a/capyregex.html
+++ b/capyregex.html
@@ -21,6 +21,8 @@
     .btn{background:#2563eb;color:#fff;border-radius:.5rem;padding:.625rem .9rem;font-weight:700}.btn:hover{background:#1d4ed8}
     .chip{background:rgba(255,255,255,.06);border:1px solid var(--glass-border);padding:.4rem .6rem;border-radius:.6rem}
   </style>
+  <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="min-h-screen flex flex-col text-[15px]">
   <header class="bg-zinc-900/80 backdrop-blur-md shadow-lg flex justify-between items-center fixed top-0 left-0 right-0 z-40 h-16 px-4 sm:px-6">

--- a/capyresumo.html
+++ b/capyresumo.html
@@ -126,6 +126,7 @@
         }
     </style>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -280,7 +281,7 @@
             const prompt = `Por favor, gere ${lengthInstruction} do seguinte texto: "${originalText}". Responda apenas com o resumo.`;
             
             try {
-                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
+                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })

--- a/capyroteiro.html
+++ b/capyroteiro.html
@@ -99,6 +99,7 @@
         .markdown-output h3 { font-size: 1.25rem; } .markdown-output h4 { font-size: 1.125rem; }
     </style>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -300,7 +301,7 @@
             `;
             
             try {
-                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
+                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })

--- a/capyseo.html
+++ b/capyseo.html
@@ -81,6 +81,7 @@
         }
     </style>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -322,7 +323,7 @@
             `;
             
             try {
-                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
+                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })

--- a/capysimulador.html
+++ b/capysimulador.html
@@ -100,6 +100,7 @@
         .markdown-output li { margin-bottom: 0.25rem; }
     </style>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">

--- a/capyslides.html
+++ b/capyslides.html
@@ -63,6 +63,7 @@
     }
   </style>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="min-h-screen flex flex-col text-[15px]">
   <!-- Header -->

--- a/capysolar.html
+++ b/capysolar.html
@@ -93,6 +93,7 @@
         .markdown-output li { margin-bottom: 0.25rem; }
     </style>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 
 <body class="dark min-h-screen flex flex-col text-[15px]">

--- a/capysolucao.html
+++ b/capysolucao.html
@@ -110,6 +110,7 @@
 
     </style>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -292,7 +293,7 @@
             `;
             
             try {
-                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
+                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })

--- a/capysqlcoach.html
+++ b/capysqlcoach.html
@@ -23,6 +23,8 @@
     .area{min-height:160px}
   </style>
   <script src="https://cdn.jsdelivr.net/npm/sql-formatter@15.3.2/dist/sql-formatter.min.js"></script>
+  <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="min-h-screen flex flex-col text-[15px]">
   <header class="bg-zinc-900/80 backdrop-blur-md shadow-lg flex justify-between items-center fixed top-0 left-0 right-0 z-40 h-16 px-4 sm:px-6">

--- a/capysub.html
+++ b/capysub.html
@@ -22,6 +22,8 @@
     .chip{background:rgba(255,255,255,.06);border:1px solid var(--glass-border);padding:.35rem .6rem;border-radius:.6rem}
     .cue{border:1px solid var(--glass-border)}
   </style>
+  <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="min-h-screen flex flex-col text-[15px]">
 <header class="bg-zinc-900/80 backdrop-blur-md shadow-lg flex justify-between items-center fixed top-0 left-0 right-0 z-40 h-16 px-4 sm:px-6">

--- a/capytabela.html
+++ b/capytabela.html
@@ -337,6 +337,7 @@
   gtag('config', 'G-3FFD7ZEBN1');
 </script>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -557,7 +558,7 @@
             chatHistory.push({ role: "user", parts: [{ text: prompt }] });
 
             const payload = { contents: chatHistory };
-            const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${geminiApiKey}`;
+            const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${geminiApiKey}`;
 
             const response = await fetch(apiUrl, {
                 method: 'POST',
@@ -617,7 +618,7 @@
             const payload = { 
                 contents: chatHistory,
             };
-            const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${geminiApiKey}`;
+            const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${geminiApiKey}`;
 
             const response = await fetch(apiUrl, {
                 method: 'POST',

--- a/capytcc.html
+++ b/capytcc.html
@@ -94,6 +94,7 @@
     </script>
 
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -288,7 +289,7 @@
             `;
             
             try {
-                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
+                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })

--- a/capyteste.html
+++ b/capyteste.html
@@ -93,6 +93,7 @@
         }
     </style>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -332,7 +333,7 @@
             `;
             
             try {
-                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
+                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })

--- a/capyti.html
+++ b/capyti.html
@@ -87,6 +87,7 @@
 </script>
 
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -286,7 +287,7 @@
             `;
             
             try {
-                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
+                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })

--- a/capytone.html
+++ b/capytone.html
@@ -71,6 +71,7 @@
         }
     </style>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -215,7 +216,7 @@
             const prompt = `Reescreva o seguinte texto para que ele tenha um tom ${selectedTone.toLowerCase()}: "${originalText}". Responda apenas com o texto ajustado.`;
             
             try {
-                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
+                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })

--- a/capytradutor.html
+++ b/capytradutor.html
@@ -71,6 +71,7 @@
         }
     </style>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -263,7 +264,7 @@
             }
             
             try {
-                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
+                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })

--- a/capyvagamatch.html
+++ b/capyvagamatch.html
@@ -70,6 +70,7 @@
         }
     </style>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -326,7 +327,7 @@
             const prompt = `Como um especialista em RH, analise o seguinte currículo e a descrição da vaga. Currículo: """${cvText}""" Descrição da Vaga: """${jobText}""" Forneça uma análise detalhada em formato JSON com as chaves: "matchScore" (0-100), "skillsBreakdown" ({labels: array, scores: array}), "swot" ({strengths: array, weaknesses: array, opportunities: array, threats: array}), "coverLetterDraft" (string). Responda APENAS com o objeto JSON.`;
             
             try {
-                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
+                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })

--- a/capyvalor.html
+++ b/capyvalor.html
@@ -91,6 +91,7 @@
   gtag('config', 'G-3FFD7ZEBN1');
 </script>
   <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white flex flex-col min-h-screen">
 
@@ -338,7 +339,7 @@
             `;
 
             try {
-                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
+                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })

--- a/capywatermark.html
+++ b/capywatermark.html
@@ -24,6 +24,8 @@
     .dropzone.dragover{outline:2px dashed #7c5cff;outline-offset:-6px}
     .hidden-input{position:absolute;inset:0;opacity:0}
   </style>
+  <script src="cu-init.js"></script>
+  <script src="cu-app.js" defer></script>
 </head>
 <body class="min-h-screen flex flex-col text-[15px]">
   <header class="bg-zinc-900/80 backdrop-blur-md shadow-lg flex justify-between items-center fixed top-0 left-0 right-0 z-40 h-16 px-4 sm:px-6">

--- a/cu-app.js
+++ b/cu-app.js
@@ -1,0 +1,313 @@
+(() => {
+  const API_KEY_STORAGE_KEY = 'capyUniverseApiKey_gemini';
+
+  function shouldSkip() {
+    const body = document.body;
+    return !body || body.dataset.cuSkipShell === 'true' || body.dataset.cuSkipShell === '1';
+  }
+
+  function applyBackground() {
+    const body = document.body;
+    if (!body) return;
+    body.classList.add('min-h-screen', 'flex', 'flex-col');
+    body.classList.remove('bg-gray-900', 'bg-gray-950', 'text-white');
+
+    if (!body.querySelector('.cu-stars')) {
+      const stars = document.createElement('div');
+      stars.className = 'cu-stars';
+      stars.dataset.cuGenerated = 'true';
+      body.insertBefore(stars, body.firstChild);
+    }
+    if (!body.querySelector('.cu-stage')) {
+      const stage = document.createElement('div');
+      stage.className = 'cu-stage';
+      stage.dataset.cuGenerated = 'true';
+      body.insertBefore(stage, body.firstChild);
+    }
+  }
+
+  function deriveToolName() {
+    const body = document.body;
+    if (!body) return 'CapyUniverse';
+    const fromAttr = body.getAttribute('data-tool-name');
+    if (fromAttr) return fromAttr.trim();
+    const meta = document.querySelector('meta[name="tool-name"]');
+    if (meta?.content) return meta.content.trim();
+    const title = document.title || '';
+    const candidate = title.split(/[\-|—|–|\u2014|\u2013|:]/)[0]?.trim();
+    if (candidate) return candidate;
+    return 'CapyUniverse';
+  }
+
+  function toolAbbr(name) {
+    const letters = (name || '').replace(/[^A-Za-z0-9]/g, '').slice(0, 3);
+    return (letters || 'CU').toUpperCase();
+  }
+
+  function createLogoEl(abbr) {
+    const span = document.createElement('span');
+    span.className = 'cu-logo';
+    span.textContent = abbr;
+    return span;
+  }
+
+  function ensureBrand(header, name) {
+    if (!header) return;
+    header.classList.add('cu-header');
+
+    const headerChildren = Array.from(header.children);
+    let brandWrap = header.querySelector('.cu-brand');
+    if (!brandWrap) {
+      brandWrap = headerChildren.find(child => child.querySelector?.('#sidebarToggleBtn')) || headerChildren[0];
+      if (brandWrap) {
+        brandWrap.classList.add('cu-brand');
+      }
+    } else {
+      brandWrap.classList.add('cu-brand');
+    }
+
+    const toggleBtn = header.querySelector('#sidebarToggleBtn');
+    if (toggleBtn) {
+      toggleBtn.className = 'lg:hidden p-2 rounded-md text-gray-300 hover:bg-white/10 focus:outline-none';
+    }
+
+    if (brandWrap) {
+      let info = brandWrap.querySelector('.cu-brand-info');
+      if (!info) {
+        info = document.createElement('div');
+        info.className = 'flex items-center gap-2 cu-brand-info';
+        const toMove = Array.from(brandWrap.childNodes).filter(node => {
+          if (node === toggleBtn) return false;
+          if (node === info) return false;
+          return true;
+        });
+        toMove.forEach(node => info.appendChild(node));
+        brandWrap.appendChild(info);
+      }
+
+      if (!info.querySelector('.cu-logo')) {
+        info.insertBefore(createLogoEl(toolAbbr(name)), info.firstChild);
+      }
+
+      let brandNameEl = info.querySelector('.cu-appname');
+      if (!brandNameEl) {
+        brandNameEl = info.querySelector('a, span, strong, h1');
+        if (!brandNameEl) {
+          brandNameEl = document.createElement('span');
+          info.appendChild(brandNameEl);
+        }
+      }
+      brandNameEl.textContent = name;
+      brandNameEl.classList.add('cu-appname', 'text-xl');
+      if (brandNameEl.tagName === 'A') {
+        brandNameEl.href = 'index.html';
+        brandNameEl.style.textDecoration = 'none';
+        brandNameEl.style.color = 'inherit';
+      }
+
+      let chip = info.querySelector('.cu-chip');
+      if (!chip) {
+        chip = document.createElement('span');
+        info.appendChild(chip);
+      }
+      chip.textContent = 'CapyUniverse';
+      chip.className = 'cu-chip hidden sm:inline-flex';
+    }
+
+    const actions = headerChildren.find(child => child !== brandWrap) || headerChildren[1];
+    if (actions) {
+      actions.className = 'flex items-center gap-2 cu-header-actions';
+    }
+  }
+
+  function ensureHeaderButtons() {
+    const actions = document.querySelector('.cu-header-actions');
+    if (!actions) return;
+
+    const homeBtn = Array.from(actions.querySelectorAll('button')).find(btn => /in[ií]cio/i.test(btn.textContent || ''));
+    if (homeBtn) {
+      homeBtn.className = 'cu-btn hidden sm:inline-flex';
+      if (!homeBtn.getAttribute('onclick')) {
+        homeBtn.onclick = () => { window.location.href = 'index.html'; };
+      }
+    } else {
+      const btn = document.createElement('button');
+      btn.className = 'cu-btn hidden sm:inline-flex';
+      btn.type = 'button';
+      btn.textContent = 'Início';
+      btn.addEventListener('click', () => { window.location.href = 'index.html'; });
+      actions.insertBefore(btn, actions.firstChild);
+    }
+
+    const hasModal = !!document.getElementById('apiKeysModal');
+    let apiBtn = document.getElementById('openApiKeysModalButton');
+    if (!apiBtn && hasModal) {
+      apiBtn = document.createElement('button');
+      apiBtn.id = 'openApiKeysModalButton';
+      apiBtn.type = 'button';
+      apiBtn.textContent = 'Chaves API';
+      actions.appendChild(apiBtn);
+    }
+    if (apiBtn) {
+      apiBtn.className = 'cu-btn primary hidden sm:inline-flex';
+    }
+  }
+
+  function stylizeLayout() {
+    const layout = Array.from(document.querySelectorAll('body > div')).find(div => div.querySelector('main') && div.querySelector('#sidebar'));
+    if (layout) {
+      layout.className = 'flex flex-1 pt-16 min-h-0';
+    }
+
+    const sidebar = document.getElementById('sidebar');
+    if (sidebar) {
+      sidebar.className = 'sidebar-glass text-gray-300 w-64 space-y-1 p-3 fixed inset-y-0 left-0 transform -translate-x-full lg:translate-x-0 lg:static lg:inset-0 transition-transform duration-300 ease-in-out z-30 shadow-lg overflow-y-auto pt-4 scrollbar-thin';
+    }
+
+    const overlay = document.getElementById('sidebarOverlay');
+    if (overlay) {
+      overlay.className = 'fixed inset-0 bg-black/60 z-20 hidden lg:hidden';
+    }
+
+    const main = document.querySelector('main');
+    if (main) {
+      main.className = 'flex-1 min-h-0 p-4 sm:p-6 lg:p-8 overflow-y-auto w-full';
+    }
+
+    const primaryPanels = [];
+    if (main) {
+      const directSections = main.querySelectorAll(':scope > section');
+      if (directSections.length) {
+        directSections.forEach(section => primaryPanels.push(section));
+      } else {
+        const firstChild = main.firstElementChild;
+        if (firstChild) primaryPanels.push(firstChild);
+      }
+    }
+
+    primaryPanels.forEach((panel, idx) => {
+      panel.classList.add('cu-panel');
+      panel.classList.remove('glass');
+      if (!panel.classList.contains('cu-panel-padded')) {
+        panel.classList.add('cu-panel-padded');
+        panel.classList.add('p-5', 'sm:p-6', 'lg:p-8');
+      }
+    });
+  }
+
+  function ensureFabButton() {
+    if (!document.getElementById('apiKeysModal')) return;
+    let fab = document.getElementById('fabApi');
+    if (!fab) {
+      fab = document.createElement('button');
+      fab.id = 'fabApi';
+      fab.type = 'button';
+      fab.textContent = '🔑';
+      document.body.appendChild(fab);
+    }
+    fab.className = 'sm:hidden fixed bottom-4 right-4 cu-btn primary rounded-full p-3 shadow-xl z-50';
+    fab.title = 'Chaves API';
+  }
+
+  function stylizeApiModal() {
+    const modal = document.getElementById('apiKeysModal');
+    if (!modal) return;
+    modal.className = 'fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center z-50 hidden p-4';
+    const sheet = modal.querySelector(':scope > div');
+    if (sheet) {
+      sheet.classList.remove('glass');
+      sheet.classList.add('cu-panel', 'p-6', 'w-full', 'max-w-md');
+    }
+    const closeBtn = document.getElementById('closeApiKeysModalButton');
+    if (closeBtn) {
+      closeBtn.className = 'cu-btn';
+      closeBtn.type = 'button';
+      if (!closeBtn.textContent?.trim()) closeBtn.textContent = '✕';
+    }
+    const saveBtn = document.getElementById('saveGeminiKey');
+    if (saveBtn) {
+      saveBtn.classList.add('cu-btn', 'primary');
+      saveBtn.type = 'button';
+    }
+    const input = document.getElementById('geminiApiKeyInputModal');
+    if (input) {
+      input.classList.add('cu-input');
+    }
+    const fieldWrapper = input?.parentElement;
+    if (fieldWrapper && fieldWrapper instanceof HTMLElement) {
+      fieldWrapper.classList.add('flex');
+      input.classList.add('rounded-r-none');
+      if (saveBtn) saveBtn.classList.add('rounded-l-none');
+    }
+  }
+
+  function attachFabBehaviour() {
+    const modal = document.getElementById('apiKeysModal');
+    if (!modal) return;
+    const fab = document.getElementById('fabApi');
+    const openBtn = document.getElementById('openApiKeysModalButton');
+    const closeBtn = document.getElementById('closeApiKeysModalButton');
+    if (fab && openBtn) {
+      if (!fab.dataset.cuBound) {
+        fab.addEventListener('click', () => {
+          modal.classList.remove('hidden');
+        });
+        fab.dataset.cuBound = '1';
+      }
+    }
+    if (modal && !modal.dataset.cuBound) {
+      modal.addEventListener('click', (ev) => {
+        if (ev.target === modal) {
+          modal.classList.add('hidden');
+        }
+      });
+      modal.dataset.cuBound = '1';
+    }
+    if (closeBtn && !closeBtn.dataset.cuBound) {
+      closeBtn.addEventListener('click', () => modal.classList.add('hidden'));
+      closeBtn.dataset.cuBound = '1';
+    }
+  }
+
+  function highlightSidebar() {
+    const sidebar = document.getElementById('sidebar');
+    if (!sidebar) return;
+    const current = window.location.pathname.split('/').pop();
+    sidebar.querySelectorAll('a[href]').forEach(link => {
+      const href = link.getAttribute('href');
+      if (!href) return;
+      if (href === current) {
+        link.classList.add('active');
+      }
+    });
+  }
+
+  function loadApiKeyIntoModal() {
+    const input = document.getElementById('geminiApiKeyInputModal');
+    if (!input) return;
+    try {
+      const saved = localStorage.getItem(API_KEY_STORAGE_KEY);
+      if (saved) input.value = saved;
+    } catch (err) {
+      console.warn('cu-app: unable to read API key', err);
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    if (shouldSkip()) return;
+    try {
+      const toolName = deriveToolName();
+      applyBackground();
+      ensureBrand(document.querySelector('body > header'), toolName);
+      ensureHeaderButtons();
+      stylizeLayout();
+      ensureFabButton();
+      stylizeApiModal();
+      attachFabBehaviour();
+      highlightSidebar();
+      loadApiKeyIntoModal();
+    } catch (err) {
+      console.error('cu-app init error:', err);
+    }
+  });
+})();

--- a/cu-style.css
+++ b/cu-style.css
@@ -43,6 +43,11 @@ body{
     radial-gradient(1200px 700px at 70% -10%, rgba(139,92,246,.25), transparent 60%),
     radial-gradient(900px 600px at -10% 20%, rgba(34,211,238,.18), transparent 60%),
     var(--cu-bg-0);
+  position:relative;
+}
+
+body::before{
+  content:none !important;
 }
 
 /* Decorative starfield used on some pages. To activate it, place
@@ -146,6 +151,25 @@ body{
   border-color:transparent;
 }
 
+.cu-logo{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:1.9rem;
+  height:1.9rem;
+  border-radius:999px;
+  font-size:.8rem;
+  font-weight:700;
+  letter-spacing:.4px;
+  color:white;
+  background:linear-gradient(140deg, rgba(14,165,233,.9) 0%, rgba(34,211,238,.9) 45%, rgba(168,85,247,.9) 80%, rgba(245,158,11,.95) 100%);
+  box-shadow:0 8px 22px rgba(15,23,42,.35), inset 0 0 0 1px rgba(255,255,255,.18);
+}
+
+.cu-header-actions .cu-btn{
+  box-shadow:var(--cu-shadow);
+}
+
 /* Form elements share a consistent look. */
 .cu-input,
 .cu-select,
@@ -170,6 +194,40 @@ body{
   background: linear-gradient(180deg, rgba(255,255,255,.03), transparent);
   backdrop-filter: blur(15px);
   border-right:1px solid rgba(255,255,255,.06);
+}
+
+.sidebar-link{
+  display:flex;
+  align-items:center;
+  gap:.55rem;
+  padding:.45rem .6rem;
+  border-radius:12px;
+  color:var(--cu-text-dim) !important;
+  transition:color .2s ease, background .2s ease, transform .2s ease;
+  border:1px solid transparent;
+}
+
+.sidebar-link:hover{
+  background:rgba(255,255,255,.08) !important;
+  color:var(--cu-text) !important;
+  transform:translateX(2px);
+}
+
+.sidebar-link.active{
+  background:linear-gradient(130deg, rgba(34,211,238,.2), rgba(244,114,208,.2));
+  border-color:rgba(255,255,255,.18);
+  color:white !important;
+  box-shadow:0 10px 20px rgba(15,23,42,.35);
+}
+
+.category-content{
+  max-height:0;
+  overflow:hidden;
+  transition:max-height .35s ease;
+}
+
+.category-content.expanded{
+  max-height:1600px;
 }
 
 /* Simple card component often used for galleries. */
@@ -219,4 +277,8 @@ body{
 /* Override for .font-syne to avoid loading the Syne typeface. */
 .font-syne{
   font-family:Inter,system-ui,sans-serif !important;
+}
+
+#apiKeysModal .cu-btn.primary{
+  box-shadow:none;
 }


### PR DESCRIPTION
## Summary
- add a shared `cu-app.js` bootstrap that injects the CapyUniverse chrome, styles headers, sidebars, API modal controls and syncs stored keys across tools
- extend `cu-style.css` with the gradients, logo badge, sidebar link and chip styling used by CapyIMG so every tool inherits the new look and feel
- hook each Capy tool HTML page to load the new shell script while letting CapyIMG opt out of rehydration so its bespoke layout stays intact
- update every Gemini-powered tool to call the `gemini-2.0-flash` endpoint so the ecosystem targets the latest model

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de942f83fc832f8e22fb59bfa2eaaa